### PR TITLE
Implement storage of actors in the database

### DIFF
--- a/app/federation/actors.ts
+++ b/app/federation/actors.ts
@@ -1,18 +1,47 @@
+import Actor from '#models/actor'
 import { federation } from '#start/federation'
-import { Person } from '@fedify/fedify'
+import { Endpoints, exportJwk, generateCryptoKeyPair, importJwk, Person } from '@fedify/fedify'
 
-federation.setActorDispatcher('/actors/{identifier}', async (ctx, identifier) => {
-  if (identifier !== 'me') {
-    return null // Other than "me" is not found.
-  }
+federation
+  .setActorDispatcher('/actors/{identifier}', async (ctx, identifier) => {
+    if (identifier !== 'me') return null
 
-  ctx.data.logger.info('Hello from Fedify')
-
-  return new Person({
-    id: ctx.getActorUri(identifier),
-    name: 'Me', // Display name
-    summary: 'This is me!', // Bio
-    preferredUsername: identifier, // Bare handle
-    url: new URL('/', ctx.url),
+    const actorKeys = await ctx.getActorKeyPairs(identifier)
+    return new Person({
+      id: ctx.getActorUri(identifier),
+      name: 'Me',
+      summary: 'This is me!',
+      preferredUsername: identifier,
+      url: new URL('/', ctx.url),
+      inbox: ctx.getInboxUri(identifier),
+      endpoints: new Endpoints({
+        sharedInbox: ctx.getInboxUri(),
+      }),
+      // The public keys of the actor; they are provided by the key pairs
+      // dispatcher we define below:
+      publicKeys: actorKeys.map((keyPair) => keyPair.cryptographicKey),
+    })
   })
-})
+  .setKeyPairsDispatcher(async (_ctx, identifier) => {
+    if (identifier !== 'me') return [] // Other than "me" is not found.
+
+    const actor = await Actor.findBy('identifier', identifier)
+    if (actor === null) {
+      // Generate a new key pair at the first time:
+      const { privateKey, publicKey } = await generateCryptoKeyPair('RSASSA-PKCS1-v1_5')
+      // Store the generated key pair to the Deno KV database in JWK format:
+      Actor.create({
+        identifier,
+        publicKey: await exportJwk(publicKey),
+        privateKey: await exportJwk(privateKey),
+      })
+
+      return [{ privateKey, publicKey }]
+    }
+
+    _ctx.data.logger.debug(actor)
+    // Load the key pair from the Deno KV database:
+    const privateKey = await importJwk(JSON.parse(actor.privateKey), 'private')
+    const publicKey = await importJwk(JSON.parse(actor.publicKey), 'public')
+    return [{ privateKey, publicKey }]
+  })

--- a/app/federation/inbox.ts
+++ b/app/federation/inbox.ts
@@ -1,0 +1,43 @@
+import { federation, kv } from '#start/federation'
+import { Create, Follow, isActor, Note, Reject } from '@fedify/fedify'
+
+federation
+  .setInboxListeners('/actors/{identifier}/inbox', '/inbox')
+  .on(Follow, async (ctx, follow) => {
+    if (follow.id === null || follow.actorId === null || follow.objectId === null) {
+      return
+    }
+
+    const parsed = ctx.parseUri(follow.objectId)
+    if (parsed?.type !== 'actor' || parsed.identifier !== 'me') {
+      return
+    }
+
+    const follower = await follow.getActor(ctx)
+    ctx.data.logger.debug(follower)
+
+    if (follower === null) return
+
+    // Note that if a server receives a `Follow` activity, it should reply
+    // with either an `Accept` or a `Reject` activity.  In this case, the
+    // server automatically accepts the follow request:
+    await ctx.sendActivity(
+      { identifier: parsed.identifier },
+      follower,
+      new Reject({ actor: follow.objectId, object: follow })
+    )
+    // Store the follower in the key–value store:
+    await kv.set(['followers', follow.id.href], follow.actorId.href)
+  })
+  .on(Create, async (ctx, create) => {
+    const object = await create.getObject()
+    if (!(object instanceof Note)) return
+    const actor = create.actorId
+    if (actor === null) return
+    const author = await object.getAttribution()
+    if (!isActor(author) || author.id?.href !== actor.href) return
+
+    const content = object.content?.toString()
+
+    ctx.data.logger.info({ content, author }, 'New note!')
+  })

--- a/app/middleware/fedify_middleware.ts
+++ b/app/middleware/fedify_middleware.ts
@@ -105,16 +105,12 @@ export default class FedifyMiddleware {
       }
     }
 
-    const rawBody = req.raw()
-
     return new Request(url, {
       method: req.method(),
       headers,
       duplex: 'half',
       body:
-        req.method() === 'GET' || req.method() === 'HEAD' || rawBody === null
-          ? undefined
-          : Readable.from(rawBody),
+        req.method() === 'GET' || req.method() === 'HEAD' ? undefined : Readable.toWeb(req.request),
     })
   }
 

--- a/app/models/actor.ts
+++ b/app/models/actor.ts
@@ -1,0 +1,22 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column } from '@adonisjs/lucid/orm'
+
+export default class Actor extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare identifier: string
+
+  @column()
+  declare privateKey: string
+
+  @column()
+  declare publicKey: string
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/database/migrations/1751236906963_create_actors_table.ts
+++ b/database/migrations/1751236906963_create_actors_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'actors'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table.text('identifier').notNullable()
+      table.text('private_key')
+      table.text('public_key')
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@adonisjs/vite": "^4.0.0",
     "@deno/kv": "^0.10.0",
     "@fedify/fedify": "^1.7.0",
+    "@logtape/logtape": "^1.0.0",
     "@vinejs/vine": "^3.0.1",
     "edge.js": "^6.2.1",
     "fast-glob": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@fedify/fedify':
         specifier: ^1.7.0
         version: 1.7.0(web-streams-polyfill@3.3.3)
+      '@logtape/logtape':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@vinejs/vine':
         specifier: ^3.0.1
         version: 3.0.1

--- a/start/federation.ts
+++ b/start/federation.ts
@@ -6,7 +6,11 @@ export type Context = {
   logger: HttpContext['logger']
 }
 
+export const kv = new MemoryKvStore()
+
 export const federation = createFederation<Context>({
   origin: env.get('PUBLIC_URL'),
   kv: new MemoryKvStore(),
+  // firstKnock: 'draft-cavage-http-signatures-12',
+  allowPrivateAddress: true,
 })

--- a/start/logging.ts
+++ b/start/logging.ts
@@ -37,3 +37,15 @@ emitter.on('http:request_completed', ({ ctx, duration }) => {
     `request ${ctx.request.method()} ${ctx.request.url()} status=${ctx.response.getStatus()} rt=${responseTime}`
   )
 })
+
+// For Fedify:
+import { configure, getConsoleSink } from '@logtape/logtape'
+
+await configure({
+  sinks: { console: getConsoleSink() },
+  filters: {},
+  loggers: [
+    { category: ['logtape', 'meta'], sinks: ['console'] },
+    { category: 'fedify', sinks: ['console'] },
+  ],
+})


### PR DESCRIPTION
Had a few issues with bad data ending up in denoKv due to changing public URLs for both my mastodon server and this server, had to use a local tunnel due to SSL issues — nothing likes self-signed certificates. 

There was a bug in request body handling, where sometimes it wouldn't receive the full body. Turns out I can get the body a different way and that makes mastodon happy.